### PR TITLE
Change from `mark` to `pch` for compatibility with survival update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: survSAKK
 Type: Package
 Title: Create Publication Ready Kaplan-Meier Plots
-Version: 1.3.2
+Version: 1.3.3
 Authors@R: 
     c(
   person(given = "Vithersan", family = "Somasundaram", role = c("aut"), email = "Vithersan.Somasundaram@sakk.ch"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# survSAKK 1.3.3
+
+Internal adaptation to make package compatible with new version if survival: 
+`pch` instead of `mark`.
+
+
+--------------------------------------------------------------------------------
+
+
 # survSAKK 1.3.2
 
 This update brings a new functionality `letter` and the possibility of adding several segments.

--- a/R/surv.plot.R
+++ b/R/surv.plot.R
@@ -720,7 +720,7 @@ surv.plot <- function(
     lwd = rep(lwd.main, arm_no),
     # Add censoring information with ticks
     mark.time = censoring.mark,
-    mark = "/",
+    pch = 3,
     cex = censoring.cex,                  # increase mark for censored patients.
     # Modify Layout
     xaxs = "i", yaxs = "i",               # Start axis exactly from zero origin


### PR DESCRIPTION
Dear Steffi 

I changed the argument `mark` to `pch` inside the `surv.plot` function so that it is compatible with the next update of the survival package. 

With this option, it is not possible to have the "\" for the censoring mark, so I chose "+" instead. 


Please check and merge if everything ok. 

Thank you and best wishes 
Charlotte 