### PR TITLE
Fix risk table calculation using summary.survfit

### DIFF
--- a/R/surv.plot.R
+++ b/R/surv.plot.R
@@ -1583,23 +1583,27 @@ if (length(segment.timepoint) == 1 | length(segment.quantile) == 1){
   #----------------------------------------------------------------------------#
   ### 5.1.2 Number at risk ####
   #----------------------------------------------------------------------------#
-  # Initialize a matrix 'n.risk.matrix' with zeros
-  n.risk.matrix <- matrix(0,nrow = length(xticks), ncol = arm_no)
+  # Use summary.survfit to get correct risk table values at specified time points
+  # This is the standard approach and correctly handles:
+  # - Interpolation at exact timepoints
 
-  # Loop over each arm and each time point defined by 'xticks'
-  for (stratum_i in 1:arm_no) {
-    for (x in 1:length(xticks)) {
-      # Find the indices where the survival time for the current group is
-      # greater than the current 'xticks'
-      index <- which(fit$time[grp == stratum_i] > xticks[x])
-      # If there are no such indices,
-      # set the corresponding element in 'n.risk.matrix' to 0
-      if (length(index) == 0)
-        n.risk.matrix[x,stratum_i] <- 0
-      else
-        # Otherwise, set the element to the minimum number at risk
-        # for the specified group and time point
-        n.risk.matrix[x,stratum_i] <- fit$n.risk[grp == stratum_i][min(index)]
+  # - Edge cases (times before first event, after last event)
+  # - Proper alignment with strata
+  summary_fit <- summary(fit, times = xticks, extend = TRUE)
+
+  # Initialize matrix
+  n.risk.matrix <- matrix(0, nrow = length(xticks), ncol = arm_no)
+
+  if (arm_no == 1) {
+    # Single arm - directly use n.risk from summary
+    n.risk.matrix[, 1] <- summary_fit$n.risk
+  } else {
+    # Multiple arms - extract n.risk by strata
+    strata_names <- names(fit$strata)
+    for (stratum_i in 1:arm_no) {
+      # Find indices for this stratum in summary output
+      strata_match <- summary_fit$strata == strata_names[stratum_i]
+      n.risk.matrix[, stratum_i] <- summary_fit$n.risk[strata_match]
     }
   }
 


### PR DESCRIPTION
## Summary

This PR fixes a bug in the risk table calculation that can produce incorrect number-at-risk values at specified timepoints.

## The Problem

The current implementation uses a manual loop to calculate the number at risk:

```r
for (stratum_i in 1:arm_no) {
  for (x in 1:length(xticks)) {
    index <- which(fit$time[grp == stratum_i] > xticks[x])
    if (length(index) == 0)
      n.risk.matrix[x,stratum_i] <- 0
    else
      n.risk.matrix[x,stratum_i] <- fit$n.risk[grp == stratum_i][min(index)]
  }
}
```

**Issues with this approach:**

1. **Off-by-one error**: The code looks for times *strictly greater than* `xticks[x]` (`> xticks[x]`), then takes `n.risk` at `min(index)`. This returns the number at risk *after* the first event following the timepoint, not *at* the timepoint itself.

2. **Incorrect handling of exact timepoints**: When `xticks[x]` exactly matches an event time, the current logic skips that time and reports n.risk from the next event.

3. **Edge case failures**: When there are no events after a timepoint, it returns 0 even if patients are still at risk (censored after the last event).

### Example

Consider a simple dataset where:
- At time 0: 100 patients at risk
- At time 6: 80 patients at risk (20 events/censored between 0-6)
- At time 12: 50 patients at risk

If `xticks = c(0, 6, 12)` and an event occurs exactly at time 6:
- **Current code**: May report the n.risk *after* time 6 (e.g., 79) instead of *at* time 6 (80)
- **Fixed code**: Correctly reports 80

## The Solution

Replace the manual loop with `summary.survfit()`, which is the standard method for extracting survival estimates at specific timepoints:

```r
summary_fit <- summary(fit, times = xticks, extend = TRUE)

n.risk.matrix <- matrix(0, nrow = length(xticks), ncol = arm_no)

if (arm_no == 1) {
  n.risk.matrix[, 1] <- summary_fit$n.risk
} else {
  strata_names <- names(fit$strata)
  for (stratum_i in 1:arm_no) {
    strata_match <- summary_fit$strata == strata_names[stratum_i]
    n.risk.matrix[, stratum_i] <- summary_fit$n.risk[strata_match]
  }
}
```

**Why this is correct:**

1. `summary.survfit()` with `times` argument is specifically designed to extract survival information at arbitrary timepoints
2. The `extend = TRUE` argument properly handles times beyond the last observed event
3. It correctly handles the left-continuous nature of the survival function (n.risk is the count *just before* the specified time)
4. It's the approach recommended in the `survival` package documentation

## Testing

- All existing tests pass
- Package check: 0 errors, 0 warnings, 0 notes

## References

- Therneau TM, Grambsch PM (2000). *Modeling Survival Data: Extending the Cox Model*. Springer.
- `?summary.survfit` documentation in the survival package